### PR TITLE
Remove useless import

### DIFF
--- a/gem/utils/plot_util.py
+++ b/gem/utils/plot_util.py
@@ -1,7 +1,6 @@
 import matplotlib
 import matplotlib.pyplot as plt
 import random
-import pandas as pd
 
 def get_node_color(node_community):
     cnames = [item[0] for item in matplotlib.colors.cnames.iteritems()]


### PR DESCRIPTION
Pandas is not a dependency and it's not automatically installed with
the setup.py script. As a consequence, the utilis/plot_util.py script fails
if Pandas is not already installed.