### PR TITLE
A potential bug in evaluate_link_prediction script

### DIFF
--- a/gem/evaluation/evaluate_link_prediction.py
+++ b/gem/evaluation/evaluate_link_prediction.py
@@ -62,8 +62,9 @@ def evaluateStaticLinkPrediction(digraph, graph_embedding,
         is_undirected=is_undirected,
         edge_pairs=eval_edge_pairs
     )
-
-    filtered_edge_list = [e for e in predicted_edge_list if not train_digraph.has_edge(e[0], e[1])]
+    if node_l is None:
+	    node_l = list(range(train_digraph.number_of_nodes())
+    filtered_edge_list = [e for e in predicted_edge_list if not train_digraph.has_edge(node_l(e[0]), node_l(e[1]))]
 
     MAP = metrics.computeMAP(filtered_edge_list, test_digraph)
     prec_curv, _ = metrics.computePrecisionCurve(

--- a/gem/evaluation/evaluate_link_prediction.py
+++ b/gem/evaluation/evaluate_link_prediction.py
@@ -63,7 +63,7 @@ def evaluateStaticLinkPrediction(digraph, graph_embedding,
         edge_pairs=eval_edge_pairs
     )
     if node_l is None:
-	    node_l = list(range(train_digraph.number_of_nodes())
+        node_l = list(range(train_digraph.number_of_nodes())
     filtered_edge_list = [e for e in predicted_edge_list if not train_digraph.has_edge(node_l(e[0]), node_l(e[1]))]
 
     MAP = metrics.computeMAP(filtered_edge_list, test_digraph)


### PR DESCRIPTION
Note that if n_sample_nodes is not None, then we sample a specified number of nodes for evaluation. The graph_util.sample_graph() method relabels the new residual network as well as sampling nodes!! So the predicted links in the list have totally different labels with train_digraph. We need to 'translate' the node to train_digraph for filtering purpose.