### PR TITLE
Avoid two errors during setup 

### DIFF
--- a/gem/evaluation/evaluate_link_prediction.py
+++ b/gem/evaluation/evaluate_link_prediction.py
@@ -63,7 +63,7 @@ def evaluateStaticLinkPrediction(digraph, graph_embedding,
         edge_pairs=eval_edge_pairs
     )
     if node_l is None:
-        node_l = list(range(train_digraph.number_of_nodes())
+        node_l = list(range(train_digraph.number_of_nodes()))
     filtered_edge_list = [e for e in predicted_edge_list if not train_digraph.has_edge(node_l(e[0]), node_l(e[1]))]
 
     MAP = metrics.computeMAP(filtered_edge_list, test_digraph)

--- a/setup.py
+++ b/setup.py
@@ -78,15 +78,15 @@ def git_version():
 def write_version_py(filename='gem/version.py'):
     # Copied from numpy setup.py
     cnt = """
-    # THIS FILE IS GENERATED FROM GEM SETUP.PY
-    short_version = '%(version)s'
-    version = '%(version)s'
-    full_version = '%(full_version)s'
-    git_revision = '%(git_revision)s'
-    release = %(isrelease)s
-    if not release:
-        version = full_version
-        short_version += ".dev"
+# THIS FILE IS GENERATED FROM GEM SETUP.PY
+short_version = '%(version)s'
+version = '%(version)s'
+full_version = '%(full_version)s'
+git_revision = '%(git_revision)s'
+release = '%(isrelease)s'
+if not release:
+    version = full_version
+    short_version += ".dev"
     """
     FULLVERSION = VERSION
     if os.path.exists('.git'):
@@ -103,13 +103,16 @@ def write_version_py(filename='gem/version.py'):
 
     a = open(filename, 'w')
     try:
-        a.write(cnt % {'version': VERSION,
-                       'full_version': FULLVERSION,
-                       'git_revision': GIT_REVISION,
-                       'isrelease': str(ISRELEASED)})
+        a.write(
+            cnt % {
+                'version': VERSION,
+                'full_version': FULLVERSION,
+                'git_revision': GIT_REVISION,
+                'isrelease': str(ISRELEASED)
+            }
+        )
     finally:
         a.close()
-
 
 
 def setup_package():


### PR DESCRIPTION
Fixes two error appearing during installation. 

One was caused by a wrong indentation in the long string inside `write_version_py` function. The other is just a parenthesis which was forgotten after the last PR.

By the way: thanks for the great work.