### PR TITLE
fix networkx convertion

### DIFF
--- a/gem/embedding/lle.py
+++ b/gem/embedding/lle.py
@@ -25,7 +25,7 @@ class LocallyLinearEmbedding(StaticGraphEmbedding):
         if not graph:
             raise ValueError('graph needed')
         graph = graph.to_undirected()
-        A = nx.to_scipy_sparse_matrix(graph)
+        A = nx.to_scipy_sparse_array(graph)
         normalize(A, norm='l1', axis=1, copy=False)
         i_n = sp.eye(len(graph.nodes))
         i_min_A = i_n - A


### PR DESCRIPTION
nx.to_scipy_sparse_matrix replaced by nx.to_scipy_sparse_array see: https://networkx.org/documentation/stable/reference/convert.html